### PR TITLE
Added function to clean up database and reset dangling accounts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Login server:
 - [x] Migrate to channel server
 - [x] Show worlds, channels, world status etc from information sent from world server
 - [x] Prevent players from accessing dead channel
-- [ ] Server resets login status upon restart for dangling users
+- [x] Server resets login status upon restart for dangling users
 
 World server:
 - [x] Keep track of player count

--- a/server/login.go
+++ b/server/login.go
@@ -35,6 +35,20 @@ func (server *LoginServer) Initialise(dbuser, dbpassword, dbaddress, dbport, dbd
 	}
 
 	log.Println("Connected to database")
+
+	server.CleanupDB()
+
+	log.Println("Cleaned up the database")
+}
+
+// CleanupDB sets all accounts isLogedIn to 0
+func (server *LoginServer) CleanupDB() {
+	res, err := server.db.Exec("UPDATE accounts AS a INNER JOIN characters c ON a.accountID = c.accountID SET a.isLogedIn = 0 WHERE isLogedIn = 1 AND a.accountID != ALL (SELECT c.accountID FROM characters c WHERE c.channelID != -1);")
+	if err != nil {
+		log.Fatal(err)
+	}
+	amount, _ := res.RowsAffected()
+	log.Printf("Set %d isLogedin rows to 0.", amount)
 }
 
 // HandleServerPacket from world


### PR DESCRIPTION
Query will check for any accounts locate accounts that have isLogedIn set to 1 and does not have any active online characters. This is completed by checking the channelID for all characters associated with the accountID. 