### PR TITLE
Added metrics port flag and refactored metrics initialization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,9 @@ certs/**
 database_data/**
 elastic_data/**
 
+# Binary File
+Valhalla
+
 # Folders
 _obj
 _test

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
+github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=

--- a/main.go
+++ b/main.go
@@ -3,13 +3,21 @@ package main
 import (
 	"flag"
 	"log"
+
+	"github.com/Hucaru/Valhalla/server/metrics"
 )
 
-func main() {
-	typePtr := flag.String("type", "", "Denotes what type of server to start: login, world, channel")
-	configPtr := flag.String("config", "", "config toml file")
+var typePtr, configPtr, metricPtr *string
 
+func init() {
+	typePtr = flag.String("type", "", "Denotes what type of server to start: login, world, channel")
+	configPtr = flag.String("config", "", "config toml file")
+	metricPtr = flag.String("metrics-port", "9000", "Port to serve metrics on")
 	flag.Parse()
+}
+
+func main() {
+	metrics.Port = *metricPtr
 
 	switch *typePtr {
 	case "login":

--- a/server/channel.go
+++ b/server/channel.go
@@ -167,8 +167,8 @@ func (server *ChannelServer) Initialise(work chan func(), dbuser, dbpassword, db
 	}, []string{"channel", "world"})
 
 	prometheus.MustRegister(metrics.Gauges["player_count"])
-
-	log.Println("Started serving metrics on :" + strconv.Itoa(metrics.Port))
+	metrics.StartMetrics()
+	log.Println("Started serving metrics on :" + metrics.Port)
 }
 
 // SendCountdownToPlayers - Send a countdown to players that appears as a clock

--- a/server/metrics/metrics.go
+++ b/server/metrics/metrics.go
@@ -3,14 +3,13 @@ package metrics
 import (
 	"log"
 	"net/http"
-	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Port metrics are served on
-const Port = 9000
+var Port string
 
 var (
 	// Gauges available
@@ -20,12 +19,15 @@ var (
 	Counters = make(map[string]*prometheus.CounterVec)
 )
 
-func init() {
+// StartMetrics initializes and handles metrics Prometheus endpoint
+func StartMetrics() {
 	go func() {
 		http.Handle("/metrics", promhttp.HandlerFor(
 			prometheus.DefaultGatherer,
 			promhttp.HandlerOpts{},
 		))
-		log.Fatal(http.ListenAndServe("0.0.0.0:"+strconv.Itoa(Port), nil))
+		if err := http.ListenAndServe("0.0.0.0:"+Port, nil); err != nil {
+			log.Fatal(err)
+		}
 	}()
 }


### PR DESCRIPTION
Current setup for metrics will throw errors on a single-host non-dockerized environment. Added flag to specify metrics port. Default for metrics port is 9000 if not specified so the Docker-Compose configuration will work without issue. 