### PR TITLE
Updated Dockerfile to use specific supported version of Go

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster
+FROM golang:1.15.2
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
Not tagging Dockerfile with specific Go version can sometimes cause the host machine to use a cached version of the tagged image.

By explicitly specifying supported Go version, the host machine is forced to install the correct Docker image (if not available) - thus ensuring application will run successfully for a specific version of Go. 