### PR TITLE
Upgrade go version to 1.16.0 on Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.idea/
+
+.DS_Store

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.2
+FROM golang:1.16.0
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
Update Go version in Dockerfile to support io package in `channel/script.go:114`. This is necessary because, from Go 1.16, the io package replaces ioutil, and using 1.15.2 on Dockerfile results in an `undefined: io.ReadFile` error while building containers.