### PR TITLE
fixing docker_config_cashshop.toml addresses

### DIFF
--- a/docker/docker_config_cashshop.toml
+++ b/docker/docker_config_cashshop.toml
@@ -1,12 +1,12 @@
 [database]
-address = "127.0.0.1"
+address = "db"
 port = "3306"
 user = "root"
 password = "password"
 database = "maplestory"
 
 [cashshop]
-worldAddress = "127.0.0.1"
+worldAddress = "world_server"
 worldPort = "8584"
 listenAddress = "0.0.0.0"
 listenPort = "8600"


### PR DESCRIPTION
fixing database address and worldAddress to use name instead of ip, this fixes issues with the cash shop container communicating with the other containers