### PR TITLE
updated destination names to correct names

### DIFF
--- a/scripts/portals/market00.js
+++ b/scripts/portals/market00.js
@@ -1,4 +1,4 @@
 (function () {
     const FM_ID = 910000000;
-    plr.warpFromName(FM_ID, "st00");
+    plr.warpFromName(FM_ID, "out00");
 })();

--- a/scripts/portals/out00.js
+++ b/scripts/portals/out00.js
@@ -4,7 +4,7 @@
 
     var prev = (plr.previousMap && plr.previousMap()) || 0;
     if (prev && prev > 0 && prev !== FM_ID) {
-        plr.warpFromName(prev, "st00");
+        plr.warpFromName(prev, "market00");
         return;
     }
 


### PR DESCRIPTION
FM portals are now correct:

Example using Henesys:

Henesys FM:
[
{0 {-21 -46 0} sp 999999999 false}
{1 {627 -191 0} sp 999999999 false}
{2 {525 -331 0} sp 999999999 false}
{3 {520 1 0} in01 910000001 out00 false}
{4 {673 0 0} in02 910000002 out00 false}
{5 {827 2 0} in03 910000003 out00 false}
{6 {1025 3 0} in04 910000004 out00 false}
{7 {1196 2 0} in05 910000005 out00 false}
{8 {1357 2 0} in06 910000006 out00 false}
{9 {563 -269 0} in07 910000007 out00 false}
{10 {706 -269 0} in08 910000008 out00 false}
{11 {849 -268 0} in09 910000009 out00 false}
{12 {1016 -268 0} in10 910000010 out00 false}
{13 {1172 -269 0} in11 910000011 out00 false}
{14 {1325 -267 0} in12 910000012 out00 false}
{15 {608 -538 0} in13 910000013 out00 false}
{16 {774 -538 0} in14 910000014 out00 false}
{17 {945 -537 0} in15 910000015 out00 false}
{18 {1122 -538 0} in16 910000016 out00 false}
{19 {1281 -537 0} in17 910000017 out00 false}
{20 {647 -808 0} in18 910000018 out00 false}
{21 {801 -808 0} in19 910000019 out00 false}
{22 {946 -810 0} in20 910000020 out00 false}
{23 {1094 -809 0} in21 910000021 out00 false}
{24 {1243 -809 0} in22 910000022 out00 false}
{25 {415 2 0} up00 910000000 up01 false}
{26 {457 -268 0} up01 910000000 up02 false}
{27 {503 -539 0} up02 910000000 up03 false}
{28 {552 -808 0} up03 999999999 false}
{29 {1340 -812 0} dn00 910000000 dn01 false}
{30 {1385 -539 0} dn01 910000000 dn02 false}
{31 {1428 -269 0} dn02 910000000 dn03 false}
{32 {1476 0 0} dn03 999999999 false}
{33 {-247 28 0} st00 999999999 false}
{34 {-147 29 0} out00 999999999 false} <------ FM's only have 1 out portal therefore it must be the portal we spawn in on
]

Henesys:
[
{0 {-144 84 0} sp 999999999 false}
{1 {646 47 0} sp 999999999 false}
{2 {1711 150 0} sp 999999999 false}
{3 {1937 -107 0} sp 999999999 false}
{4 {2415 151 0} sp 999999999 false}
{5 {2461 -103 0} sp 999999999 false}
{6 {3129 2 0} sp 999999999 false}
{7 {3290 -165 0} sp 999999999 false}
{8 {3998 25 0} sp 999999999 false}
{9 {3933 -231 0} sp 999999999 false}
{10 {4633 21 0} sp 999999999 false}
{11 {3354 98 0} h_east 100000100 h_west false}
{12 {1338 215 0} h_west 100000100 h_east false}
{14 {-288 155 0} out00 100000000 in00 false}
{15 {4847 95 0} out01 100000200 out01 false}
{16 {1889 212 0} in00 100000101 out00 false}
{13 {727 151 0} st00 999999999 false} <--------------- example of out of incorrect portal order
{17 {2913 -117 0} in01 100000102 out01 false}
{18 {4191 -180 0} in04 100000103 out00 false}
{19 {4165 94 0} in05 100000104 out00 false}
{20 {3653 91 0} in06 100000105 out00 false}
{21 {838 150 0} market00 999999999 false} <---- this is portal name for entering FM and therefore must be the name FM uses for leaving
]

<img width="802" height="632" alt="image" src="https://github.com/user-attachments/assets/0347f34e-3439-47a1-b95d-43f11cf9ef92" />
<img width="802" height="632" alt="image" src="https://github.com/user-attachments/assets/298bb6f2-430a-4613-ac47-82e9a0282ad3" />

Fixes #155 