### PR TITLE
Add saveBuffSnapshot during logout

### DIFF
--- a/channel/player.go
+++ b/channel/player.go
@@ -1313,7 +1313,8 @@ func (d Player) Logout() {
 	}
 
 	flushNow(&d)
-
+	d.saveBuffSnapshot()
+	
 	if err := d.save(); err != nil {
 		log.Printf("Player(%d) logout save failed: %v", d.ID, err)
 	}


### PR DESCRIPTION
This pull request introduces a small update to the `Player.Logout` function in `channel/player.go` to improve data consistency during player logout.

* Added a call to `d.saveBuffSnapshot()` in the `Logout` method to ensure the player's buff state is saved before the rest of the logout process.
* #153