### PR TITLE
Resolve boss not cleaning up properly

### DIFF
--- a/channel/boss.go
+++ b/channel/boss.go
@@ -32,19 +32,13 @@ func manageSummonedBoss(inst *fieldInstance, mobID int32, server *Server) {
 			}
 
 			inst.dispatch <- func() {
-				if len(inst.players) > 0 {
-					for _, mob := range inst.lifePool.mobs {
-						if mob.boss {
-							return
-						}
-					}
+				if len(inst.players) <= 0 {
+					inst.lifePool.eraseMobs()
+					inst.dropPool.eraseDrops()
+					inst.reactorPool.reset(false)
+					inst.properties["eventActive"] = false
+					finished.Store(true)
 				}
-
-				inst.lifePool.eraseMobs()
-				inst.dropPool.eraseDrops()
-				inst.reactorPool.reset(false)
-				inst.properties["eventActive"] = false
-				finished.Store(true)
 			}
 		case <-timeout.C:
 			var returnMap int32


### PR DESCRIPTION
This pull request updates the boss management logic in `channel/boss.go` to improve cleanup and event handling. The main changes ensure that mobs, drops, and reactors are properly reset when there are no players present, which helps prevent lingering state and potential bugs.

Boss event cleanup improvements:

* Added checks to only perform boss cleanup (erasing mobs, drops, and resetting reactors) if there are no players in the instance, preventing premature cleanup while players are still present.
* Ensured that drops are also erased during boss cleanup, in addition to mobs and reactors, to fully reset the event state.