### PR TITLE
fix(Player): fix max HP/MP Not Updating When Increased by Equipment (Issue #212)

### DIFF
--- a/channel/player.go
+++ b/channel/player.go
@@ -594,9 +594,21 @@ func (d *Player) setMaxMP(amount int16) {
 }
 
 func (d *Player) effectiveMaxHP() int16 {
+
+	var itemsHP int32 = 0
+	for _, item := range d.equip {
+		if item.hp == 0 || item.slotID > 0 {
+			continue
+		}
+
+		itemsHP += int32(item.hp)
+	}
+
 	base32 := int32(d.maxHP)
 	hpPct, _ := d.hyperBodyPercents()
-	res := base32
+
+	res := base32 + itemsHP
+
 	if hpPct > 0 {
 		res += (base32 * int32(hpPct)) / 100
 	}
@@ -610,9 +622,18 @@ func (d *Player) effectiveMaxHP() int16 {
 }
 
 func (d *Player) effectiveMaxMP() int16 {
+
+	var itemsMP int32 = 0
+	for _, item := range d.equip {
+		if item.mp == 0 || item.slotID > 0 {
+			continue
+		}
+		itemsMP += int32(item.mp)
+	}
+
 	base32 := int32(d.maxMP)
 	_, mpPct := d.hyperBodyPercents()
-	res := base32
+	res := base32 + itemsMP
 	if mpPct > 0 {
 		res += (base32 * int32(mpPct)) / 100
 	}


### PR DESCRIPTION
Additions to effectiveMaxHP/MP to iterate through items.

I'm unsure if this the optimal solution as this iterates through the equip items.
maybe filtering once at the player object level and saving as Player.EquippedItems could be better.