### PR TITLE
taxi discount and lith fix

### DIFF
--- a/channel/script.go
+++ b/channel/script.go
@@ -219,6 +219,28 @@ func (ctrl *scriptPlayerWrapper) Warp(id int32) {
 	}
 }
 
+func (ctrl *scriptPlayerWrapper) WarpToPortalName(id int32, name string) {
+	if field, ok := ctrl.server.fields[id]; ok {
+		inst, err := field.getInstance(ctrl.plr.inst.id)
+
+		if err != nil {
+			inst, err = field.getInstance(0)
+
+			if err != nil {
+				return
+			}
+		}
+
+		portal, err := inst.getPortalFromName(name)
+
+		if err != nil {
+			return
+		}
+
+		ctrl.server.warpPlayer(ctrl.plr, field, portal, true)
+	}
+}
+
 func (ctrl *scriptPlayerWrapper) SendMessage(msg string) {
 	ctrl.plr.Send(packetMessageRedText(msg))
 }

--- a/scripts/npc/1002000.js
+++ b/scripts/npc/1002000.js
@@ -1,23 +1,28 @@
 var towns = [100000000, 102000000, 101000000, 103000000]
-var prices_text = ["800", "1,000", "1,000", "1,200"]
 var prices_num = [800, 1000, 1000, 1200]
 
 npc.sendNext("There's a lot to see in this town, too. Let me know if you want to go somewhere else.")
 
 var text = "Choose your destination, for fees will change from place to place.\r\n"
 
+var discountRate = (plr.job() == 0) ? 0.10 : 1.00
+
 for (var i = 0; i  < towns.length; i++) {
-    text += "#L" + i + "##b#m" + towns[i] + "# (" + prices_text[i] +" mesos)#l \r\n"
+    var cost = Math.floor(prices_num[i] * discountRate)
+    text += "#L" + i + "##b#m" + towns[i] + "# (" + cost.toLocaleString() + " mesos)#l \r\n"
 }
 
 npc.sendSelection(text)
 
-if (npc.sendYesNo("You don't have anything else to do here, huh? Do you really want to go to #b#m" + towns[npc.selection()] + "# #k? It'll cost you #b" + prices_text[npc.selection()] + " mesos")) {
-    if (plr.mesos() < prices_num[npc.selection()]) {
+var sel = npc.selection()
+var finalCost = Math.floor(prices_num[sel] * discountRate)
+
+if (npc.sendYesNo("You don't have anything else to do here, huh? Do you really want to go to #b#m" + towns[sel] + "# #k? It'll cost you #b" + finalCost.toLocaleString() + " mesos")) {
+    if (plr.mesos() < finalCost) {
         npc.sendOk("You don't have enough mesos! Come back when you do.")
     } else {
-        plr.giveMesos(-1 * prices_num[npc.selection()])
-        plr.warp(towns[npc.selection()])
+        plr.giveMesos(-1 * finalCost)
+        plr.warp(towns[sel])
     }
 } else {
     npc.sendNext("There's a lot to see in this town, too. Come back and find us when you need to go to a different town.")

--- a/scripts/npc/1012000.js
+++ b/scripts/npc/1012000.js
@@ -1,25 +1,30 @@
 // Henesys Regular Cab
 
 var towns = [104000000, 102000000, 101000000, 103000000]
-var prices_text = ["800", "1,000", "1,000", "1,200"]
 var prices_num = [800, 1000, 1000, 1200]
 
 npc.sendNext("How's it going? I drive the Regular Cab. If you want to go from town to town safely and fast, then ride our cab. We'll gladly take you to your destination with an affordable price")
 
 var text = "Choose your destination, for fees will change from place to place.\r\n"
 
+var discountRate = (plr.job() == 0) ? 0.10 : 1.00
+
 for (var i = 0; i  < towns.length; i++) {
-    text += "#L" + i + "##b#m" + towns[i] + "# (" + prices_text[i] +" mesos)#l \r\n"
+    var cost = Math.floor(prices_num[i] * discountRate)
+    text += "#L" + i + "##b#m" + towns[i] + "# (" + cost.toLocaleString() + " mesos)#l \r\n"
 }
 
 npc.sendSelection(text)
 
-if (npc.sendYesNo("You don't have anything else to do here, huh? Do you really want to go to #b#m" + towns[npc.selection()] + "# #k? It'll cost you #b" + prices_text[npc.selection()] + " mesos")) {
-    if (plr.mesos() < prices_num[npc.selection()]) {
+var sel = npc.selection()
+var finalCost = Math.floor(prices_num[sel] * discountRate)
+
+if (npc.sendYesNo("You don't have anything else to do here, huh? Do you really want to go to #b#m" + towns[sel] + "# #k? It'll cost you #b" + finalCost.toLocaleString() + " mesos")) {
+    if (plr.mesos() < finalCost) {
         npc.sendOk("You don't have enough mesos! Come back when you do.")
     } else {
-        plr.giveMesos(-1 * prices_num[npc.selection()])
-        plr.warp(towns[npc.selection()])
+        plr.giveMesos(-1 * finalCost)
+        plr.warp(towns[sel])
     }
 } else {
     npc.sendNext("There's a lot to see in this town, too. Come back and find us when you need to go to a different town.")

--- a/scripts/npc/1022001.js
+++ b/scripts/npc/1022001.js
@@ -1,25 +1,30 @@
 // Regular Cab
 
 var towns = [104000000, 100000000, 101000000, 103000000]
-var prices_text = ["800", "1,000", "1,000", "1,200"]
 var prices_num = [800, 1000, 1000, 1200]
 
 npc.sendNext("How's it going? I drive the Regular Cab. If you want to go from town to town safely and fast, then ride our cab. We'll gladly take you to your destination with an affordable price")
 
 var text = "Choose your destination, for fees will change from place to place.\r\n"
 
+var discountRate = (plr.job() == 0) ? 0.10 : 1.00
+
 for (var i = 0; i  < towns.length; i++) {
-    text += "#L" + i + "##b#m" + towns[i] + "# (" + prices_text[i] +" mesos)#l \r\n"
+    var cost = Math.floor(prices_num[i] * discountRate)
+    text += "#L" + i + "##b#m" + towns[i] + "# (" + cost.toLocaleString() + " mesos)#l \r\n"
 }
 
 npc.sendSelection(text)
 
-if (npc.sendYesNo("You don't have anything else to do here, huh? Do you really want to go to #b#m" + towns[npc.selection()] + "# #k? It'll cost you #b" + prices_text[npc.selection()] + " mesos")) {
-    if (plr.mesos() < prices_num[npc.selection()]) {
+var sel = npc.selection()
+var finalCost = Math.floor(prices_num[sel] * discountRate)
+
+if (npc.sendYesNo("You don't have anything else to do here, huh? Do you really want to go to #b#m" + towns[sel] + "# #k? It'll cost you #b" + finalCost.toLocaleString() + " mesos")) {
+    if (plr.mesos() < finalCost) {
         npc.sendOk("You don't have enough mesos! Come back when you do.")
     } else {
-        plr.giveMesos(-1 * prices_num[npc.selection()])
-        plr.warp(towns[npc.selection()])
+        plr.giveMesos(-1 * finalCost)
+        plr.warp(towns[sel])
     }
 } else {
     npc.sendNext("There's a lot to see in this town, too. Come back and find us when you need to go to a different town.")

--- a/scripts/npc/1032000.js
+++ b/scripts/npc/1032000.js
@@ -1,25 +1,30 @@
 // Regular Cab
 
 var towns = [104000000, 102000000, 100000000, 103000000]
-var prices_text = ["800", "1,000", "1,000", "1,200"]
 var prices_num = [800, 1000, 1000, 1200]
 
 npc.sendNext("How's it going? I drive the Regular Cab. If you want to go from town to town safely and fast, then ride our cab. We'll gladly take you to your destination with an affordable price")
 
 var text = "Choose your destination, for fees will change from place to place.\r\n"
 
+var discountRate = (plr.job() == 0) ? 0.10 : 1.00
+
 for (var i = 0; i  < towns.length; i++) {
-    text += "#L" + i + "##b#m" + towns[i] + "# (" + prices_text[i] +" mesos)#l \r\n"
+    var cost = Math.floor(prices_num[i] * discountRate)
+    text += "#L" + i + "##b#m" + towns[i] + "# (" + cost.toLocaleString() + " mesos)#l \r\n"
 }
 
 npc.sendSelection(text)
 
-if (npc.sendYesNo("You don't have anything else to do here, huh? Do you really want to go to #b#m" + towns[npc.selection()] + "# #k? It'll cost you #b" + prices_text[npc.selection()] + " mesos")) {
-    if (plr.mesos() < prices_num[npc.selection()]) {
+var sel = npc.selection()
+var finalCost = Math.floor(prices_num[sel] * discountRate)
+
+if (npc.sendYesNo("You don't have anything else to do here, huh? Do you really want to go to #b#m" + towns[sel] + "# #k? It'll cost you #b" + finalCost.toLocaleString() + " mesos")) {
+    if (plr.mesos() < finalCost) {
         npc.sendOk("You don't have enough mesos! Come back when you do.")
     } else {
-        plr.giveMesos(-1 * prices_num[npc.selection()])
-        plr.warp(towns[npc.selection()])
+        plr.giveMesos(-1 * finalCost)
+        plr.warp(towns[sel])
     }
 } else {
     npc.sendNext("There's a lot to see in this town, too. Come back and find us when you need to go to a different town.")

--- a/scripts/npc/1052016.js
+++ b/scripts/npc/1052016.js
@@ -1,25 +1,30 @@
 // Regular Cab
 
 var towns = [104000000, 103000000, 102000000, 101000000, 100000000]
-var prices_text = ["1,000", "1,000", "1,000", "1,000", "1,000",]
 var prices_num = [1000, 1000, 1000, 1000, 1000]
 
 npc.sendNext("How's it going? I drive the Regular Cab. If you want to go from town to town safely and fast, then ride our cab. We'll gladly take you to your destination with an affordable price")
 
 var text = "Choose your destination, for fees will change from place to place.\r\n"
 
+var discountRate = (plr.job() == 0) ? 0.10 : 1.00
+
 for (var i = 0; i  < towns.length; i++) {
-    text += "#L" + i + "##b#m" + towns[i] + "# (" + prices_text[i] +" mesos)#l \r\n"
+    var cost = Math.floor(prices_num[i] * discountRate)
+    text += "#L" + i + "##b#m" + towns[i] + "# (" + cost.toLocaleString() + " mesos)#l \r\n"
 }
 
 npc.sendSelection(text)
 
-if (npc.sendYesNo("You don't have anything else to do here, huh? Do you really want to go to #b#m" + towns[npc.selection()] + "# #k? It'll cost you #b" + prices_text[npc.selection()] + " mesos")) {
-    if (plr.mesos() < prices_num[npc.selection()]) {
+var sel = npc.selection()
+var finalCost = Math.floor(prices_num[sel] * discountRate)
+
+if (npc.sendYesNo("You don't have anything else to do here, huh? Do you really want to go to #b#m" + towns[sel] + "# #k? It'll cost you #b" + finalCost.toLocaleString() + " mesos")) {
+    if (plr.mesos() < finalCost) {
         npc.sendOk("You don't have enough mesos! Come back when you do.")
     } else {
-        plr.giveMesos(-1 * prices_num[npc.selection()])
-        plr.warp(towns[npc.selection()])
+        plr.giveMesos(-1 * finalCost)
+        plr.warp(towns[sel])
     }
 } else {
     npc.sendNext("There's a lot to see in this town, too. Come back and find us when you need to go to a different town.")

--- a/scripts/npc/22000.js
+++ b/scripts/npc/22000.js
@@ -5,7 +5,7 @@ if (plr.itemCount(4031801) > 0) {
         npc.sendBackNext("Okay, now give me 150 mesos...Hey, what's that? Is that the recommendation letter from Lucas, the chief of Amherst? You should have told me about this earlier. I, Shanks, recognize greatness when l see it, and since you have been recommended by Lucas, l can see that you have very great potential as an adventurer. No way would l dare charge you for this trip!")
         npc.sendBackNext("Since you have the recommendation letter, I won't charge you for this. We're going to head to Victoria Island right now, so buckle up! it might get a bit turbulent!!")
         plr.removeItemsByID(4031801, 1)
-        plr.warp(104000000)
+        plr.warpToPortalName(104000000, "maple00")
     } else {
         npc.sendOk("Hmm... I guess you still have things to do here?");
     }


### PR DESCRIPTION
#221 and #222 

This pull request introduces a discount system for the Regular Cab NPC scripts, giving Beginners (job ID 0) a reduced fare, and also adds a new warp function that allows warping to a specific portal by name. Additionally, it updates the Shanks NPC to use this new warp method for a more accurate player spawn location.

**Discount system for Regular Cab NPCs:**

- Added a 90% discount on cab fares for Beginner job (job ID 0) characters in all Regular Cab NPC scripts. The displayed price and the amount deducted are now dynamically calculated and formatted, ensuring Beginners see and pay the discounted price. [[1]](diffhunk://#diff-2cb22e72d538a9f8850cad541aa8ca4f710251d00bc117240fc09f963dea35b6L2-R25) [[2]](diffhunk://#diff-63efd717830c789cb0f7faee0cee481780d5ba60070a6979d000ce6c394946daL4-R27) [[3]](diffhunk://#diff-382e3f5c40ef5c1207b01ca0bfec34ba184e63beb492a91738dcde09d18a8553L4-R27) [[4]](diffhunk://#diff-10e9d84e55f807c6e6e06b40e90a9140cba3fdf9825246741ea8d3d0e9cff6e2L4-R27) [[5]](diffhunk://#diff-8557f8bd2ed476d0ea5dc943f1e19d5cfc66d75dc3f80a9c02abba567f76fef0L4-R27)

**Warp functionality improvements:**

- Introduced a new method `WarpToPortalName` in `scriptPlayerWrapper` to warp a player to a specific portal within a map by its name, improving flexibility for scripts that need to control the player's spawn location.
- Updated the Shanks NPC script to use `warpToPortalName` instead of the basic `warp`, ensuring that players with a recommendation letter arrive at the correct portal ("maple00") on Victoria Island.