### PR TITLE
add support for critical attacks

### DIFF
--- a/channel/handlers_client.go
+++ b/channel/handlers_client.go
@@ -2607,6 +2607,7 @@ type attackInfo struct {
 	hitCount                                               byte
 	damages                                                []int32
 	mesoDropIDs                                            []int32
+	isCritical                                             []bool
 }
 
 type attackData struct {
@@ -2731,8 +2732,13 @@ func getAttackInfo(reader mpacket.Reader, player Player, attackType int) (attack
 			}
 
 			ai.damages = make([]int32, ai.hitCount)
+			ai.isCritical = make([]bool, ai.hitCount)
 			for j := byte(0); j < ai.hitCount; j++ {
 				dmg := reader.ReadInt32()
+
+				isCrit := player.rollCritical(attackType)
+				ai.isCritical[j] = isCrit
+
 				data.totalDamage += dmg
 				ai.damages[j] = dmg
 			}
@@ -2786,9 +2792,12 @@ func getAttackInfo(reader mpacket.Reader, player Player, attackType int) (attack
 		int32(rest[delayIdx+4])<<16 |
 		int32(rest[delayIdx+5])<<24
 
+	isCrit := false
+
 	data.attackInfo = []attackInfo{{
-		spawnID: spawnID,
-		damages: []int32{dmg},
+		spawnID:    spawnID,
+		damages:    []int32{dmg},
+		isCritical: []bool{isCrit},
 	}}
 	data.targets = 1
 	data.totalDamage = dmg
@@ -4580,7 +4589,16 @@ func (server *Server) playerSummonAttack(conn mnet.Client, reader mpacket.Reader
 		if at.spawnID <= 0 || len(at.damages) == 0 {
 			continue
 		}
-		mobDamages[at.spawnID] = append(mobDamages[at.spawnID], at.damages...)
+
+		criticalDamages := make([]int32, len(at.damages))
+		for idx, dmg := range at.damages {
+			if idx < len(at.isCritical) && at.isCritical[idx] {
+				criticalDamages[idx] = int32(uint32(dmg) | 0x80000000)
+			} else {
+				criticalDamages[idx] = dmg
+			}
+		}
+		mobDamages[at.spawnID] = append(mobDamages[at.spawnID], criticalDamages...)
 	}
 	if len(mobDamages) == 0 {
 		return

--- a/channel/player.go
+++ b/channel/player.go
@@ -520,6 +520,58 @@ func (d *Player) getRechargeBonus() int16 {
 	return 0
 }
 
+func (d *Player) getCriticalSkillAndRate() (int32, int) {
+	var weaponID int32 = 0
+	for _, item := range d.equip {
+		if item.slotID == constant.WeaponSlot {
+			weaponID = item.ID
+			break
+		}
+	}
+
+	if weaponID == 0 {
+		return 0, 0
+	}
+
+	weaponType := weaponID / 10000
+
+	if weaponType == constant.WeaponTypeBow || weaponType == constant.WeaponTypeCrossbow {
+		if ps, ok := d.skills[int32(skill.CriticalShot)]; ok {
+			critRate := constant.CriticalBaseRate + (int(ps.Level) * constant.CriticalRatePerLevel)
+			if critRate > constant.CriticalRateMax {
+				critRate = constant.CriticalRateMax
+			}
+			return int32(skill.CriticalShot), critRate
+		}
+	}
+
+	if weaponType == constant.WeaponTypeClaw {
+		if ps, ok := d.skills[int32(skill.CriticalThrow)]; ok {
+			critRate := constant.CriticalBaseRate + (int(ps.Level) * constant.CriticalRatePerLevel)
+			if critRate > constant.CriticalRateMax {
+				critRate = constant.CriticalRateMax
+			}
+			return int32(skill.CriticalThrow), critRate
+		}
+	}
+
+	return 0, 0
+}
+
+func (d *Player) rollCritical(attackType int) bool {
+	if attackType != attackRanged {
+		return false
+	}
+
+	skillID, critRate := d.getCriticalSkillAndRate()
+	if skillID == 0 || critRate == 0 {
+		return false
+	}
+
+	roll := d.randIntn(100)
+	return roll < critRate
+}
+
 // Send the Data a packet
 func (d *Player) Send(packet mpacket.Packet) {
 	if d == nil || d.Conn == nil {
@@ -3660,6 +3712,18 @@ func packetPlayerChairUpdate() mpacket.Packet {
 	return p
 }
 
+// writeAttackDamages writes damage values to packet
+func writeAttackDamages(p *mpacket.Packet, info attackInfo) {
+	for idx, dmg := range info.damages {
+		if idx < len(info.isCritical) && info.isCritical[idx] {
+			crit := int32(uint32(dmg) | 0x80000000)
+			p.WriteInt32(crit)
+		} else {
+			p.WriteInt32(dmg)
+		}
+	}
+}
+
 func packetSkillMelee(char Player, ad attackData) mpacket.Packet {
 	p := mpacket.CreateWithOpcode(opcode.SendChannelPlayerUseMeleeSkill)
 	p.WriteInt32(char.ID)
@@ -3691,9 +3755,7 @@ func packetSkillMelee(char Player, ad attackData) mpacket.Packet {
 			p.WriteByte(byte(len(info.damages)))
 		}
 
-		for _, dmg := range info.damages {
-			p.WriteInt32(dmg)
-		}
+		writeAttackDamages(&p, info)
 	}
 
 	return p
@@ -3730,9 +3792,7 @@ func packetSkillRanged(char Player, ad attackData) mpacket.Packet {
 			p.WriteByte(byte(len(info.damages)))
 		}
 
-		for _, dmg := range info.damages {
-			p.WriteInt32(dmg)
-		}
+		writeAttackDamages(&p, info)
 	}
 
 	return p
@@ -3769,9 +3829,7 @@ func packetSkillMagic(char Player, ad attackData) mpacket.Packet {
 			p.WriteByte(byte(len(info.damages)))
 		}
 
-		for _, dmg := range info.damages {
-			p.WriteInt32(dmg)
-		}
+		writeAttackDamages(&p, info)
 	}
 
 	return p

--- a/constant/constants.go
+++ b/constant/constants.go
@@ -599,3 +599,9 @@ const (
 	PortalDeath  int32 = 0
 	PortalNormal int32 = -1
 )
+
+const (
+	CriticalBaseRate     = 15
+	CriticalRatePerLevel = 2
+	CriticalRateMax      = 100
+)


### PR DESCRIPTION
This pull request implements support for critical hits in the attack system, specifically for ranged attacks, by tracking and encoding critical hits in damage values. It introduces logic to determine when a critical hit occurs based on weapon type and skill, and ensures critical hit information is preserved and transmitted throughout the attack handling and packet-writing process.

**Critical hit system for attacks:**

* Added an `isCritical` field to the `attackInfo` struct to track which hits are critical.
* Implemented logic in `getAttackInfo` to determine if each hit is critical for ranged attacks, using a new `rollCritical` method that checks weapon type, skill, and a random roll against the critical rate. [[1]](diffhunk://#diff-58f47af606b2ed1ca1742a51a8b1f41aa34bd82ecca1e605b23c52cb9fe4cd8fR2735-R2741) [[2]](diffhunk://#diff-7c17860a8d1d10607463092eb6652bafd66b1f34027f14eeb42fa052a1385971R523-R574)
* Introduced constants for base critical rate, per-level increase, and maximum rate in `constant/constants.go`.

**Damage encoding and propagation:**

* Updated attack handling so that critical hits are encoded into the damage value (by setting the highest bit) before being added to `mobDamages`, ensuring downstream consumers can recognize critical hits.
* Refactored packet construction for melee, ranged, and magic skills to use a new `writeAttackDamages` helper, which encodes critical hits in the outgoing packet. [[1]](diffhunk://#diff-7c17860a8d1d10607463092eb6652bafd66b1f34027f14eeb42fa052a1385971R3715-R3726) [[2]](diffhunk://#diff-7c17860a8d1d10607463092eb6652bafd66b1f34027f14eeb42fa052a1385971L3694-R3758) [[3]](diffhunk://#diff-7c17860a8d1d10607463092eb6652bafd66b1f34027f14eeb42fa052a1385971L3733-R3795) [[4]](diffhunk://#diff-7c17860a8d1d10607463092eb6652bafd66b1f34027f14eeb42fa052a1385971L3772-R3832)

These changes collectively enable the system to support critical hit mechanics for ranged attacks, with extensibility for future weapon types or skills.